### PR TITLE
Tech322/get artist albums

### DIFF
--- a/controllers/SpotifyController.js
+++ b/controllers/SpotifyController.js
@@ -1,3 +1,4 @@
+import getAlbums from "../lib/spotify/getAlbums.js";
 import searchArtist from "../lib/spotify/searchArtist.js";
 import getAccessToken from "../lib/supabase/getAccessToken.js";
 
@@ -16,6 +17,19 @@ export const getProfile = async (req, res) => {
         external_urls: artist.external_urls,
       },
     });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ error });
+  }
+};
+
+export const getArtistAlbums = async (req, res) => {
+  const { artistId } = req.query;
+  const accessToken = await getAccessToken();
+  const albums = await getAlbums(artistId, accessToken);
+  if (albums?.error) return res.status(500).json({ error: albums?.error });
+  try {
+    return res.status(200).json({ albums });
   } catch (error) {
     console.error(error);
     return res.status(500).json({ error });

--- a/lib/spotify/getAlbums.js
+++ b/lib/spotify/getAlbums.js
@@ -1,0 +1,25 @@
+import getFormattedAlbums from "./getFormattedAlbums.js";
+
+const getAlbums = async (artistId, accessToken) => {
+  try {
+    const response = await fetch(
+      `https://api.spotify.com/v1/artists/${artistId}/albums`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+    if (!response.ok) return { error: true };
+    const data = await response.json();
+    const formattedSavedAlbums = getFormattedAlbums(data?.items || []);
+    return formattedSavedAlbums;
+  } catch (error) {
+    console.error(error);
+    return { error };
+  }
+};
+
+export default getAlbums;

--- a/lib/spotify/getFormattedAlbums.js
+++ b/lib/spotify/getFormattedAlbums.js
@@ -1,0 +1,10 @@
+const getFormattedAlbums = (albums) => {
+  return albums.map((album) => ({
+    name: album.name,
+    uri: album.uri,
+    release_date: album.release_date,
+    artist: album.artists?.[0]?.name,
+  }));
+};
+
+export default getFormattedAlbums;

--- a/routes.js
+++ b/routes.js
@@ -24,6 +24,7 @@ routes.get('/get_twitter_profile' , TwitterController.getProfile) ;
 routes.get('/get_tweets' , TwitterController.getAllTweets) ;
 
 routes.get('/get_spotify_profile' , SpotifyController.getProfile) ;
+routes.get('/get_artist_albums' , SpotifyController.getArtistAlbums) ;
 
 
 export default routes;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new endpoints for retrieving Spotify artist profiles and albums.
	- Added functionality to fetch and format artist albums and profiles from Spotify.

- **Bug Fixes**
	- Enhanced error handling for Spotify API requests to ensure robust responses.

- **Chores**
	- Updated dependencies to include `@supabase/supabase-js`.
	- Established a connection to the Supabase client for database interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->