### PR TITLE
Implement Spotify artist albums API

### DIFF
--- a/controllers/SpotifyController.ts
+++ b/controllers/SpotifyController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import getSearch from "../lib/spotify/getSearch";
 import generateAccessToken from "../lib/spotify/generateAccessToken";
+import getArtistAlbums from "../lib/spotify/getArtistAlbums";
 
 export const getSpotifySearchHandler = async (req: Request, res: Response) => {
   try {
@@ -17,6 +18,42 @@ export const getSpotifySearchHandler = async (req: Request, res: Response) => {
     const { data, error } = await getSearch({
       q: String(q),
       type: String(type),
+      market: market ? String(market) : undefined,
+      limit: limit ? String(limit) : undefined,
+      offset: offset ? String(offset) : undefined,
+      accessToken: tokenResult.access_token,
+    });
+
+    if (error) {
+      return res.status(502).json({ status: "error" });
+    }
+
+    return res.status(200).json({ status: "success", ...data });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ status: "error" });
+  }
+};
+
+export const getSpotifyArtistAlbumsHandler = async (
+  req: Request,
+  res: Response
+) => {
+  try {
+    const { id, include_groups, market, limit, offset } = req.query;
+
+    if (!id || typeof id !== "string") {
+      return res.status(400).json({ status: "error" });
+    }
+
+    const tokenResult = await generateAccessToken();
+    if (!tokenResult || tokenResult.error || !tokenResult.access_token) {
+      return res.status(500).json({ status: "error" });
+    }
+
+    const { data, error } = await getArtistAlbums({
+      id,
+      include_groups: include_groups ? String(include_groups) : undefined,
       market: market ? String(market) : undefined,
       limit: limit ? String(limit) : undefined,
       offset: offset ? String(offset) : undefined,

--- a/lib/spotify/getArtistAlbums.ts
+++ b/lib/spotify/getArtistAlbums.ts
@@ -1,0 +1,50 @@
+const getArtistAlbums = async ({
+  id,
+  include_groups,
+  market,
+  limit,
+  offset,
+  accessToken,
+}: {
+  id: string;
+  include_groups?: string;
+  market?: string;
+  limit?: string | number;
+  offset?: string | number;
+  accessToken: string;
+}) => {
+  try {
+    const params = new URLSearchParams();
+    if (include_groups) params.append("include_groups", include_groups);
+    if (market) params.append("market", market);
+    if (limit) params.append("limit", String(limit));
+    if (offset) params.append("offset", String(offset));
+
+    const query = params.toString();
+    const url = `https://api.spotify.com/v1/artists/${id}/albums${
+      query ? `?${query}` : ""
+    }`;
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      return { data: null, error: new Error("Spotify API request failed") };
+    }
+
+    const data = await response.json();
+    return { data, error: null };
+  } catch (error) {
+    return {
+      data: null,
+      error: error instanceof Error ? error : new Error("Unknown error fetching artist albums"),
+    };
+  }
+};
+
+export default getArtistAlbums;

--- a/routes.ts
+++ b/routes.ts
@@ -10,7 +10,10 @@ import { getSegmentFansHandler } from "./controllers/SegmentFansController";
 import { getArtistSocialsHandler } from "./controllers/ArtistSocialsController";
 import { getSocialPostsHandler } from "./controllers/SocialPostsController";
 import { getPostCommentsHandler } from "./controllers/PostCommentsController";
-import { getSpotifySearchHandler } from "./controllers/SpotifyController";
+import {
+  getSpotifySearchHandler,
+  getSpotifyArtistAlbumsHandler,
+} from "./controllers/SpotifyController";
 import {
   searchTweetsHandler,
   getTrendsHandler,
@@ -68,6 +71,7 @@ routes.get("/social/posts", getSocialPostsHandler as any);
 routes.get("/post/comments", getPostCommentsHandler as any);
 
 routes.get("/spotify/search", getSpotifySearchHandler as any);
+routes.get("/spotify/artist/albums", getSpotifyArtistAlbumsHandler as any);
 
 routes.get("/x/search", searchTweetsHandler as any);
 routes.get("/x/trends", getTrendsHandler as any);


### PR DESCRIPTION
## Summary
- add a new `getSpotifyArtistAlbumsHandler` in `SpotifyController`
- create `getArtistAlbums` library for calling Spotify API
- wire up `/api/spotify/artist/albums` route

## Testing
- `npm test` *(fails: jest not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new endpoint to fetch albums of a Spotify artist using various filters such as group type, market, limit, and offset.
- **Bug Fixes**
  - Improved error handling for requests with missing or invalid parameters and for failures when communicating with Spotify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->